### PR TITLE
Attribute closing fix

### DIFF
--- a/hdf5lib/H5Attribute.cs
+++ b/hdf5lib/H5Attribute.cs
@@ -50,6 +50,7 @@ public class H5Attribute : H5Object
         if (Data == null)
         {
             Read(parentID);
+            Close();
         }
         else
         {

--- a/hdf5lib/H5Dataset.cs
+++ b/hdf5lib/H5Dataset.cs
@@ -443,7 +443,7 @@ namespace hdf5lib
 
         internal override void Close()
         {
-            Attributes.Close();
+            //Attributes.Close();
             H5P.close(propertyListID);
             H5S.close(dataSpaceID);
             H5D.close(ID);

--- a/hdf5lib/H5File.cs
+++ b/hdf5lib/H5File.cs
@@ -47,7 +47,7 @@ namespace hdf5lib
         /// </summary>
         public void Close()
         {
-            Attributes.Close();
+            //Attributes.Close();
             Datasets.Close();
             H5F.close(ID);
         }


### PR DESCRIPTION
Reading and writing of attributes can be self-contained, and the attributes don't need to be left open.

This fixes a raised exception when closing the main h5File, as there were methods in place to close all attributes, but at least after writing attributes, the attribute was already closed. 

I fixed this by simply closing immediately after reading the attribute, and then not having the higher level objects try to close the attributes. This might be a problem if after reading an attribute you might want to rewrite over it. But I think if you want a new value for an attribute, it might be better to just simply make a new attribute...

There are other ways of fixing this problem... 
1) don't check for and raise an exception after closing of the attributes and just assume they should be happily closed
2) reset the attributeID to 0 after closing the attribute and then always protect the closing of the attributes by check if the id is different from 0